### PR TITLE
Saves templates to disk as .png files

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -6,7 +6,7 @@
 #' @importFrom extrafont font_import
 #' @importFrom spekex read_spek
 #' @export
-main <- function(spek_path = NULL, data_path = NULL) {
+main <- function(spek_path = NULL, data_path = NULL, save_path = NULL) {
   # Read spek
   spek <- spekex::read_spek(spek_path)
 
@@ -28,6 +28,7 @@ main <- function(spek_path = NULL, data_path = NULL) {
   figures <- produce_plots(promoted, templates, data, spek)
 
   # Write plots to disk. TODO: issue12
+  save_plots(figures, save_path, promoted)
 
   # Don't print the return value
   invisible(NULL)

--- a/R/save_plots.R
+++ b/R/save_plots.R
@@ -1,0 +1,18 @@
+#' @title Save Plots
+#' @description Save the ggplots to given directory
+#' @param figures List of ggplots
+#' @param save_path Path to directory given to save the list of ggplots
+#' @export
+save_plots<- function(figures, save_path, performer_id) {
+  # Save figures to current working directory if no path is provided
+  if(is.null(save_path) || is.na(save_path)) {
+    save_path = getwd()
+  }
+  # format: performer_id-template_name.pdf
+  mapply(ggsave,
+         filename=paste(performer_id,"-",names(figures),".png", sep=""),
+         path=save_path,
+         #width=,
+         #height=,
+         plot=figures)
+}

--- a/tests/testthat/test_produce_plots.R
+++ b/tests/testthat/test_produce_plots.R
@@ -3,25 +3,27 @@ library(tibble)
 
 context('Produce plots')
 
-# Dummy templates
-foo <- new.env()
-foo$run <- function(data, spek){ ggplot2::ggplot() }
-bar <- new.env()
-bar$run <- function(data, spek){ ggplot2::ggplot() }
-dummy_templates <- list('foo'=foo, 'bar'=bar)
-
-va_data <- read_data(spekex::get_data_path("va"))
-va_spek <- spekex::read_spek(spekex::get_spek_path("va"))
-
 templates <- load_templates()
 
+CANDI_1 <- list( `@id` = "http://example.com/app/candidate1",
+                 `@type` = "http://example.com/cpo#cpo_0000053")
+CANDI_1[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"E87746")))
+CANDI_1[PT$ANC_TEMPLATE_URI]  <- list( list(`@value` = paste0(PT$APP_BASE_URI,"TopPerformerGraph")))
+CANDI_1[PT$PROMOTED_URI] <- list(list(`@id` = "http://example.com/slowmo#default_esteemer_criteria"))
 
+CANDI_2 <- list( `@id` = "http://example.com/app/candidate2",
+                 `@type` = "http://example.com/cpo#cpo_0000053")
+CANDI_2[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"E87746")))
+CANDI_2[PT$ANC_TEMPLATE_URI]  <- list( list(`@value` = paste0(PT$APP_BASE_URI,"IUDGraph")))
+CANDI_2[PT$PROMOTED_URI] <- list(list(`@id` = "http://example.com/slowmo#default_esteemer_criteria"))
+
+PROMOTED_CANDIDATES <- list(CANDI_1, CANDI_2 )
 
 test_that("retuns a list of ggplot objects with mtxdata",{
   mtx_data <- read_data(spekex::get_data_path("mtx"))
   mtx_spek <- spekex::read_spek(spekex::get_spek_path("mtx"))
-  promoted <- "E87746"
-  mtx_templates <- c(templates$TopPerformerGraph, templates$IUDGraph)
+  template_idxs <- match(c("TopPerformerGraph", "IUDGraph"), names(templates))
+  mtx_templates <- templates[template_idxs]
 
-  result <- produce_plots(promoted, mtx_templates, mtx_data, mtx_spek)
+  result <- produce_plots(PROMOTED_CANDIDATES, mtx_templates, mtx_data, mtx_spek)
 })

--- a/tests/testthat/test_produce_plots.R
+++ b/tests/testthat/test_produce_plots.R
@@ -10,10 +10,18 @@ bar <- new.env()
 bar$run <- function(data, spek){ ggplot2::ggplot() }
 dummy_templates <- list('foo'=foo, 'bar'=bar)
 
-test_that("retuns a list of ggplot objects",{
-  skip("pending")
-  dummy_data <- tibble('id'=c(a,b,c), 'val'=c(10,20,30))
-  dummy_promoted <- list()
-  dummy_templates <- list()
-  result <- produce_plots(dummy_promoted, dummy_templates, dummy_data, dummy_spek)
+va_data <- read_data(spekex::get_data_path("va"))
+va_spek <- spekex::read_spek(spekex::get_spek_path("va"))
+
+templates <- load_templates()
+
+
+
+test_that("retuns a list of ggplot objects with mtxdata",{
+  mtx_data <- read_data(spekex::get_data_path("mtx"))
+  mtx_spek <- spekex::read_spek(spekex::get_spek_path("mtx"))
+  promoted <- "E87746"
+  mtx_templates <- c(templates$TopPerformerGraph, templates$IUDGraph)
+
+  result <- produce_plots(promoted, mtx_templates, mtx_data, mtx_spek)
 })

--- a/tests/testthat/test_produce_plots.R
+++ b/tests/testthat/test_produce_plots.R
@@ -5,6 +5,7 @@ context('Produce plots')
 
 templates <- load_templates()
 
+# Candidate Nodes for mtx data
 CANDI_1 <- list( `@id` = "http://example.com/app/candidate1",
                  `@type` = "http://example.com/cpo#cpo_0000053")
 CANDI_1[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"E87746")))
@@ -17,13 +18,45 @@ CANDI_2[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"E8
 CANDI_2[PT$ANC_TEMPLATE_URI]  <- list( list(`@value` = paste0(PT$APP_BASE_URI,"IUDGraph")))
 CANDI_2[PT$PROMOTED_URI] <- list(list(`@id` = "http://example.com/slowmo#default_esteemer_criteria"))
 
-PROMOTED_CANDIDATES <- list(CANDI_1, CANDI_2 )
+MTX_PROMOTED_CANDIDATES <- list(CANDI_1, CANDI_2)
 
-test_that("retuns a list of ggplot objects with mtxdata",{
+# Candidate nodes for va data
+CANDI_3 <- list( `@id` = "http://example.com/app/candidate3",
+                 `@type` = "http://example.com/cpo#cpo_0000053")
+CANDI_3[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"6559AA")))
+CANDI_3[PT$ANC_TEMPLATE_URI]  <- list( list(`@value` = paste0(PT$APP_BASE_URI,"SingleLineGraph")))
+CANDI_3[PT$PROMOTED_URI] <- list(list(`@id` = "http://example.com/slowmo#default_esteemer_criteria"))
+
+CANDI_4 <- list( `@id` = "http://example.com/app/candidate4",
+                 `@type` = "http://example.com/cpo#cpo_0000053")
+CANDI_4[PT$ANC_PERFORMER_URI] <- list(list(`@value` = paste0(PT$APP_BASE_URI,"6559AA")))
+CANDI_4[PT$ANC_TEMPLATE_URI]  <- list( list(`@value` = paste0(PT$APP_BASE_URI,"ComparisonLineGraph")))
+CANDI_4[PT$PROMOTED_URI] <- list(list(`@id` = "http://example.com/slowmo#default_esteemer_criteria"))
+
+VA_PROMOTED_CANDIDATES <- list(CANDI_3, CANDI_4)
+
+
+
+test_that("produce_plots returns a list of ggplot objects with mtxdata", {
   mtx_data <- read_data(spekex::get_data_path("mtx"))
   mtx_spek <- spekex::read_spek(spekex::get_spek_path("mtx"))
   template_idxs <- match(c("TopPerformerGraph", "IUDGraph"), names(templates))
   mtx_templates <- templates[template_idxs]
 
-  result <- produce_plots(PROMOTED_CANDIDATES, mtx_templates, mtx_data, mtx_spek)
+  result <- produce_plots(MTX_PROMOTED_CANDIDATES, mtx_templates, mtx_data, mtx_spek)
+
+  expect_s3_class(result[[1]], "ggplot")
+  expect_true(length(result) == 2)
+})
+
+test_that("produce_plots returns a list of ggplot objects with vadata", {
+  va_data <- read_data(spekex::get_data_path("va"))
+  va_spek <- spekex::read_spek(spekex::get_spek_path("va"))
+  template_idxs <- match(c("SingleLineGraph", "ComparisonLineGraph"), names(templates))
+  va_templates <- templates[template_idxs]
+
+  result <- produce_plots(VA_PROMOTED_CANDIDATES, va_templates, va_data, va_spek)
+
+  expect_s3_class(result[[1]], "ggplot")
+  expect_true(length(result) == 2)
 })

--- a/tests/testthat/test_save_plot.R
+++ b/tests/testthat/test_save_plot.R
@@ -1,0 +1,42 @@
+library(ggplot2)
+library(tibble)
+
+context('Save Plots')
+
+# Dummy templates
+foo <- ggplot2::ggplot()
+bar <- ggplot2::ggplot()
+dummy_templates <- list('foo'=foo, 'bar'=bar)
+performer_id <- "baz"
+
+# Displaylab templates
+templates <- load_templates()
+
+test_that("templates are saved in save_path directory with .png format", {
+  save_path <- getwd()
+  save_plots(dummy_templates, save_path, performer_id)
+
+  current_files <- list.files(path=save_path, pattern=".png")
+  expected_files <- c("baz-bar.png", "baz-foo.png")
+  do_match <- current_files == expected_files
+  expect_true(all(do_match))
+  file.remove(current_files)
+})
+
+test_that("templates are saved in current directory by default", {
+  save_path <- NA
+  save_plots(dummy_templates, save_path, performer_id)
+
+  current_files <- list.files(path=getwd(), pattern=".png")
+  expected_files <- c("baz-bar.png", "baz-foo.png")
+  do_match <- current_files == expected_files
+  expect_true(all(do_match))
+  file.remove(current_files)
+})
+
+test_that("templates successfully save displaylab templates", {
+  skip("current data examples (va/mtx) will not produce a complete list of templates")
+  save_path <- NA
+  save_plots()
+})
+


### PR DESCRIPTION
Closes #12 
Produce_plots now has test cases included to ensure that the function accepts a list of promoted candidates, spek, and data and returns a list of ggplot objects to be saved to disk.