### PR TITLE
Maintains uniform dimensions across templates

### DIFF
--- a/R/package_constants.r
+++ b/R/package_constants.r
@@ -32,3 +32,7 @@ PT$DL_LIGHT_BORDER <- "#e7edee" # used in TopPerformerGraph
 
 # Style-guide font
 PT$DL_FONT <- "Montserrat"
+
+# Template dimensions
+PT$DL_WIDTH <- 10
+PT$DL_HEIGHT <- 10

--- a/R/save_plots.R
+++ b/R/save_plots.R
@@ -12,7 +12,7 @@ save_plots<- function(figures, save_path, performer_id) {
   mapply(ggsave,
          filename=paste(performer_id,"-",names(figures),".png", sep=""),
          path=save_path,
-         #width=,
-         #height=,
+         width=PT$DL_WIDTH,
+         height=PT$DL_HEIGHT,
          plot=figures)
 }


### PR DESCRIPTION
A test could be added to this issue that will confirm the graphs are saved with the correct dimensions. The [png library](https://www.rdocumentation.org/packages/png/versions/0.1-7/topics/readPNG) has a convenient readPNG() function that can be piped into dim() which will return the width/height of the .png file. 