### PR TITLE
Fixups to squash warnings

### DIFF
--- a/inst/templates/ComparisonBarGraphVERT.R
+++ b/inst/templates/ComparisonBarGraphVERT.R
@@ -79,7 +79,7 @@ run <- function(recipient, data, spek){
                color=PT$DL_FILL, label.r = unit(0, "lines"),
                family=PT$DL_FONT) +
     geom_text(mapping = aes(label=show_you),
-              nudge_y = 0.14, fill=PT$DL_BLUE,
+              nudge_y = 0.14,
               size=3, family=PT$DL_FONT) +
     scale_y_continuous(limits=c(0,1.15), expand=c(0,0), breaks=breaks_y, labels = labels_y) +
     scale_x_discrete(df$performers, expand=expand_scale(add=c(0.65,2)), labels = labels_x) +

--- a/inst/templates/ComparisonLineGraph.R
+++ b/inst/templates/ComparisonLineGraph.R
@@ -7,7 +7,7 @@ library(pictoralist)
 run <- function(recipient, data, spek){
   color_palette <- c(PT$DL_RED, PT$DL_LIGHT_BLUE, PT$DL_CYAN, PT$DL_ORANGE)
 
-  performers <- data %>%
+    performers <- data %>%
     group_by(sta6a) %>%
     summarise(documented = sum(documented), total = sum(total)) %>%
     mutate(percentage = floor(100*documented / total)) %>%
@@ -64,7 +64,8 @@ run <- function(recipient, data, spek){
   #Group colors to ids
   non_recipients <- unique(ids[ids != recipient])
   modified_palette <- list()
-  modified_palette[non_recipients] <- color_palette
+  num_performers <- length(modified_palette[non_recipients])
+  modified_palette[non_recipients] <- head(color_palette, num_performers)
   modified_palette[recipient] <- PT$DL_BLUE
   modified_palette <- unlist(modified_palette)
 

--- a/inst/templates/SingleLineGraph.R
+++ b/inst/templates/SingleLineGraph.R
@@ -41,6 +41,7 @@ run <- function(recipient, data, spek){
   # Gets date interval and adds to max for GOAL geom_text()
   min_date <- min(df$dates)
   max_date <- max(df$dates)
+
   days_interval <- max_date - min_date
   goal_offset <- floor(days_interval/10)
 

--- a/tests/testthat/test_integration_builtin_templates.r
+++ b/tests/testthat/test_integration_builtin_templates.r
@@ -19,14 +19,14 @@ test_that("Baked in templates with single time points work with mtx data",{
 })
 
 test_that("Baked in templates with single time points work with va data",{
-  mtx_data <- read_data(spekex::get_data_path("va"))
-  mtx_spek <- spekex::read_spek(spekex::get_spek_path("va"))
+  va_data <- read_data(spekex::get_data_path("va"))
+  va_spek <- spekex::read_spek(spekex::get_spek_path("va"))
 
   templates <- load_templates()
   va_templates <- c(templates$SingleLineGraph)
 
   results <- lapply(va_templates, FUN=function(t, recip, data, spek){t$run(recip, data, spek)},
-                    recip = "E87746", data=mtx_data, spek=mtx_spek)
+                    recip = "6559AA", data=va_data, spek=va_spek)
   is_ggplot <- sapply(results, function(x){"ggplot" %in% class(x)})
   expect_true(all(is_ggplot))
 })


### PR DESCRIPTION
All warnings are squashed except for issues caused by min/max in single line graph. 
After a lot of research, min/max seem to be evaluating a character vector of length 0 resulting in NA. I've tried many approaches to remove the NA values, but none were successful. 
[This post](https://stackoverflow.com/questions/50766089/summarizing-data-with-na-rm-true) seems to be related to the warning.
